### PR TITLE
Ignore promise/always-return rule in the last callback

### DIFF
--- a/config-backend.js
+++ b/config-backend.js
@@ -1,10 +1,11 @@
 module.exports = {
-    extends: ['./index.js'],
-    env: {
-      node: true,
-      mongo: true
-    },
-    rules: {
-      'node/no-unpublished-require': 'warn'
-    }
-  };
+  extends: ['./index.js'],
+  env: {
+    node: true,
+    mongo: true,
+  },
+  rules: {
+    'node/no-unpublished-require': 'warn',
+    'promise/always-return': [{ ignoreLastCallback: true }],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafflebox-technologies-inc/eslint-config-rafflebox",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "index.js",
   "repository": "https://github.com/rafflebox-technologies-inc/eslint-config-rafflebox",
   "author": "Jamie Archibald <jamie@rafflebox.ca>",


### PR DESCRIPTION
The linter complains about not having a `return` statement with no value in the last callback.

Here's an example:
<img width="718" alt="Screenshot 2023-03-17 at 3 21 56 PM" src="https://user-images.githubusercontent.com/8559466/225987197-86389612-cb1c-4780-8173-279d7aa9e72c.png">

Here's how to resolve the warning, but the `return` statement is redundant:
<img width="735" alt="Screenshot 2023-03-17 at 3 22 36 PM" src="https://user-images.githubusercontent.com/8559466/225987327-35a109b9-52d6-49b4-b4b4-545f365e0b7c.png">