### PR TITLE
Add workflow dispatch option to publish scripts

### DIFF
--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - packages/common/package.json
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-jest.yml
+++ b/.github/workflows/publish-jest.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - packages/jest/package.json
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - packages/ts/package.json
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-vitest.yml
+++ b/.github/workflows/publish-vitest.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - packages/vitest/package.json
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-vue2.yml
+++ b/.github/workflows/publish-vue2.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - packages/vue2/package.json
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-vue3.yml
+++ b/.github/workflows/publish-vue3.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - packages/vue3/package.json
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Add a workflow dispatch option to the publish workflows. The previous publish errored, I fixed the issue but the workflows only automatically trigger if you change the package.json file (like version number). So this will let me fix the mistake.