### PR TITLE
Fix vitest and ts package incompatibility

### DIFF
--- a/packages/vitest/index.mjs
+++ b/packages/vitest/index.mjs
@@ -1,4 +1,4 @@
-import vitest from 'eslint-plugin-vitest';
+import vitest from '@vitest/eslint-plugin';
 
 export default [
   {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -9,11 +9,10 @@
   "packageManager": "yarn@4.2.2+sha256.1aa43a5304405be7a7cb9cb5de7b97de9c4e8ddd3273e4dad00d6ae3eb39f0ef",
   "prettier": "@rafflebox-technologies-inc/rafflebox-prettier-config",
   "dependencies": {
-    "eslint-plugin-vitest": "^0.5.4"
+    "@vitest/eslint-plugin": "^1.3.4"
   },
   "devDependencies": {
-    "eslint": ">=9.26.0",
-    "eslint-plugin-vitest": "^0.5.4"
+    "eslint": ">=9.26.0"
   },
   "peerDependencies": {
     "eslint": ">=9.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,6 +1039,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rafflebox-technologies-inc/eslint-config-rafflebox-vitest@workspace:packages/vitest"
   dependencies:
+    "@vitest/eslint-plugin": "npm:^1.3.4"
     eslint: "npm:>=9.26.0"
     eslint-plugin-vitest: "npm:^0.5.4"
   peerDependencies:
@@ -1608,7 +1609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.41.0":
+"@typescript-eslint/utils@npm:8.41.0, @typescript-eslint/utils@npm:^8.24.1":
   version: 8.41.0
   resolution: "@typescript-eslint/utils@npm:8.41.0"
   dependencies:
@@ -1681,6 +1682,24 @@ __metadata:
   version: 1.2.0
   resolution: "@ungap/structured-clone@npm:1.2.0"
   checksum: 10c0/8209c937cb39119f44eb63cf90c0b73e7c754209a6411c707be08e50e29ee81356dca1a848a405c8bdeebfe2f5e4f831ad310ae1689eeef65e7445c090c6657d
+  languageName: node
+  linkType: hard
+
+"@vitest/eslint-plugin@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "@vitest/eslint-plugin@npm:1.3.4"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.24.1"
+  peerDependencies:
+    eslint: ">= 8.57.0"
+    typescript: ">= 5.0.0"
+    vitest: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 10c0/26ee3fabfcbd37d55ccf4912bf0e12ee85320c362096ff9537f70dc094364419f25e626c62e7b94d93f758fb732d34811438c669ad58ea080c29d5a4ac459c05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There is a new vitest eslint plugin I didn't realize, this fixes an incompatible version issue with typescript-eslint plugin.